### PR TITLE
feat: extend fen to display hidden squares needed for "dark chess"

### DIFF
--- a/assets/styles/cm-chessboard.css
+++ b/assets/styles/cm-chessboard.css
@@ -64,6 +64,10 @@
 .cm-chessboard.default .board .square.black {
   fill: #c5a076; }
 
+.cm-chessboard.default .board .square.hidden{
+  fill: #909090;
+}
+
 .cm-chessboard.default.border-type-thin .board .border {
   stroke: #c5a076;
   stroke-width: 0.7%;

--- a/src/cm-chessboard/Chessboard.js
+++ b/src/cm-chessboard/Chessboard.js
@@ -98,8 +98,8 @@ export class Chessboard {
         for (const extensionData of this.props.extensions) {
             this.extensions.push(new extensionData.class(this, extensionData.props))
         }
-        this.view.redrawBoard()
         this.state.position = new Position(this.props.position)
+        this.view.redrawBoard()
         this.view.redrawPieces()
         this.state.invokeExtensionPoints(EXTENSION_POINT.positionChanged)
     }

--- a/src/cm-chessboard/model/Position.js
+++ b/src/cm-chessboard/model/Position.js
@@ -30,18 +30,28 @@ export class Position {
         }
         const parts = fenNormalized.replace(/^\s*/, "").replace(/\s*$/, "").split(/\/|\s/)
         for (let part = 0; part < 8; part++) {
+            let character = "-";
             const row = parts[7 - part].replace(/\d/g, (str) => {
-                const numSpaces = parseInt(str)
                 let ret = ''
-                for (let i = 0; i < numSpaces; i++) {
-                    ret += '-'
+                const numOfChar = parseInt(str)
+                if (numOfChar == 9){
+                    character = "h"
+                    return ret
+                } 
+                for (let i = 0; i < numOfChar ; i++) {
+                    ret += character
+                }
+                if (numOfChar != 9){
+                    character = "-"
                 }
                 return ret
             })
             for (let c = 0; c < 8; c++) {
                 const char = row.substring(c, c + 1)
                 let piece = null
-                if (char !== '-') {
+                if (char == "h"){
+                    piece = "h"
+                } else if (char !== '-') {
                     if (char.toUpperCase() === char) {
                         piece = `w${char.toLowerCase()}`
                     } else {

--- a/src/cm-chessboard/view/ChessboardView.js
+++ b/src/cm-chessboard/view/ChessboardView.js
@@ -204,7 +204,10 @@ export class ChessboardView {
 
         for (let i = 0; i < 64; i++) {
             const index = this.chessboard.state.orientation === COLOR.white ? i : 63 - i
-            const squareColor = ((9 * index) & 8) === 0 ? 'black' : 'white'
+            let squareColor = ((9 * index) & 8) === 0 ? 'black' : 'white'
+            if (this.chessboard.state.position.squares[i] == "h"){
+                squareColor = "hidden"
+            }
             const fieldClass = `square ${squareColor}`
             const point = this.squareToPoint(Position.indexToSquare(index))
             const squareRect = Svg.addElement(this.boardGroup, "rect", {


### PR DESCRIPTION
Hidden squares are represented by the number 9 followed by the number of consecutive hidden squares. e.g. 92 means two hidden squares side by side. 
/4931/ - 4 empty squares, 3 hidden squares, 1 empty square